### PR TITLE
Change namespace to Aprismatic

### DIFF
--- a/BigIntegerExt/BigIntegerExt.cs
+++ b/BigIntegerExt/BigIntegerExt.cs
@@ -11,7 +11,7 @@ using System;
 using System.Numerics;
 using System.Security.Cryptography;
 
-namespace Aprismatic.BigIntegerExt
+namespace Aprismatic
 {
     public static class BigIntegerExt
     {

--- a/BigIntegerExt/BigIntegerExt.csproj
+++ b/BigIntegerExt/BigIntegerExt.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.1.1.0</Version>
     <Description>A set of extension methods for the .NET `System.Numerics.BigInteger` class, including methods like `ModInverse`, `GenPseudoPrime`, `GenRandomBits` (using cryptographically strong RNG), `IsProbablePrime` (implemented using Rabin-Miller test).</Description>
     <Company>Nanyang Technological Unviersity</Company>
     <Product>BigIntegerExt</Product>
     <Authors>Vasily Sidorov (bazzilic)</Authors>
+    <RootNamespace>Aprismatic</RootNamespace>
   </PropertyGroup>
 </Project>

--- a/BigIntegerExtTest/BigIntegerExtTests.cs
+++ b/BigIntegerExtTest/BigIntegerExtTests.cs
@@ -1,4 +1,4 @@
-﻿using Aprismatic.BigIntegerExt;
+﻿using Aprismatic;
 using System;
 using System.Linq;
 using System.Numerics;


### PR DESCRIPTION
This makes more sense as the class will be Aprismatic.BigIntegerExt, instead of Aprismatic.BigIntegerExt.BigIntegerExt