### PR TITLE
.NET 6.0 compatibility

### DIFF
--- a/src/Aprismatic.BigIntegerExt/BigIntegerExt.cs
+++ b/src/Aprismatic.BigIntegerExt/BigIntegerExt.cs
@@ -189,7 +189,7 @@ namespace Aprismatic
         {
             if (bits < 2) throw new ArgumentOutOfRangeException(nameof(bits), bits, "GenPseudoPrime can only generate prime numbers of 2 bits or more");
 
-            BigInteger result;
+            BigInteger result = new BigInteger();
             var done = false;
 
             while (!done)
@@ -225,7 +225,7 @@ namespace Aprismatic
 
             do
             {
-                BigInteger q;
+                BigInteger q = new BigInteger();
                 var qbits = bits - 1;
 
                 var done = false;


### PR DESCRIPTION
First of all, thanks for the great extension methods, looks very solid!

However, the current code is not compatible with .NET 6.0, just because of a small security feature that doesn't allow us to return unassigned variables - which of course we don't _really_ do, but the compiler isn't smart enough to recognize the difference.

The changes are not really worth mentioning, only 2 BigInteger objects had to be instantiated.